### PR TITLE
Fix exception handling on Java 6

### DIFF
--- a/src/openperipheral/core/util/StringUtils.java
+++ b/src/openperipheral/core/util/StringUtils.java
@@ -22,4 +22,8 @@ public class StringUtils {
 			sb.append(r[i] + d);
 		return sb.toString() + r[i];
 	}
+	
+	public static boolean isEmpty(String str){
+	  return str == null || "".equals(str);
+	}
 }


### PR DESCRIPTION
Exception handling uses a java 7 feature (ReflectiveOperationException) which causes it to throw an exception in the exception handling on Java 6, so error messages vanish and OpenP locks up the computer/turtle forever.

This changes exception handling to be agnostic about what types of exceptions it is handling, just determine which exception of source and/or cause has a message and return that. 
