### PR TITLE
Changed run to accept the other spelling, removed runPart.

### DIFF
--- a/assets/openperipheral/lua/github
+++ b/assets/openperipheral/lua/github
@@ -104,50 +104,51 @@ if sCommand == "get" then
     end
 
 elseif sCommand == "run" then
-  if #tArgs >= 3 then
-  local sPath = tArgs[2]
-  
-  local res = getFull(sPath)
-  if res then
-    local func, err = loadstring(res)
-    if not func then
-      printError( err )
+  if string.find(tArgs[2],"/") then
+    if #tArgs >= 2 then
+    local sPath = tArgs[2]
+
+    local res = getFull(sPath)
+    if res then
+      local func, err = loadstring(res)
+      if not func then
+        printError( err )
+        return
+      end
+      setfenv(func, getfenv())
+      local success, msg = pcall(func, unpack(tArgs, 3))
+      if not success then
+        printError( msg )
+      end
+    end
+    else
+      printUsage()
       return
     end
-    setfenv(func, getfenv())
-    local success, msg = pcall(func, unpack(tArgs, 3))
-    if not success then
-      printError( msg )
-    end
-  end
   else
-    printUsage()
-    return
-  end
+    if #tArgs >= 5 then
+      local sName = tArgs[2]
+      local sRepo = tArgs[3]
+      local sBranch = tArgs[4]
+      local sPath = tArgs[5]
 
-elseif sCommand == "runPart" then
-  if #tArgs >= 6 then
-  local sName = tArgs[2]
-  local sRepo = tArgs[3]
-  local sBranch = tArgs[4]
-  local sPath = tArgs[5]
-
-  local res = get(sName,sRepo,sBranch,sPath)
-  if res then
-    local func, err = loadstring(res)
-    if not func then
-      printError( err )
+      local res = get(sName,sRepo,sBranch,sPath)
+      if res then
+        local func, err = loadstring(res)
+        if not func then
+          printError( err )
+          return
+        end
+        setfenv(func, getfenv())
+        local success, msg = pcall(func, unpack(tArgs, 6))
+        if not success then
+          printError( msg )
+        end
+      end
+    else
+      printUsage()
       return
     end
-    setfenv(func, getfenv())
-    local success, msg = pcall(func, unpack(tArgs, 6))
-    if not success then
-      printError( msg )
-    end
-  end
-  else
-    printUsage()
-    return
   end
 elseif sCommand == "help" then
   term.clear()
@@ -158,7 +159,8 @@ elseif sCommand == "help" then
   print ("")
   print("There is also another spelling:")
   print("github get <username> <reponame> <branch> <path> <filename>")
-  print("github runPart <username> <reponame> <branch> <path> <arguments>")
+  print("github run <username> <reponame> <branch> <path> [arguments]")
+  print("Note: Do not use the '/' (slash) character with this spelling!")
 else
     printUsage()
     return


### PR DESCRIPTION
string.find(tArgs[2],"/") was my friend. Also, I added a new line to the help.
