### PR TITLE
Adding a Blacklist registry to API

### DIFF
--- a/src/openperipheral/OpenPeripheral.java
+++ b/src/openperipheral/OpenPeripheral.java
@@ -4,7 +4,6 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.ItemStack;
 import net.minecraft.src.ModLoader;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityCommandBlock;
 import openperipheral.api.BlacklistRegistry;
 import openperipheral.core.AdapterManager;
 import openperipheral.core.BasicMount;
@@ -117,7 +116,6 @@ public class OpenPeripheral {
 	public void preInit(FMLPreInitializationEvent evt) {
 		ConfigSettings.loadAndSaveConfig(evt.getSuggestedConfigurationFile());
 		MountingUtils.refreshLatestFiles();
-
 	}
 
 	@Mod.EventHandler
@@ -148,9 +146,6 @@ public class OpenPeripheral {
 			RobotUpgradeManager.registerUpgradeProvider(new ProviderInventoryUpgrade());
 			RobotUpgradeManager.registerUpgradeProvider(new ProviderTargetingUpgrade());
 		}
-		
-		BlacklistRegistry.registerTileEntity(TileEntityCommandBlock.class);
-		BlacklistRegistry.registerTileEntity(IPeripheral.class);
 		
 		ModuleVanilla.init();
 
@@ -185,6 +180,8 @@ public class OpenPeripheral {
 		if (ModLoader.isModLoaded(Mods.THAUMCRAFT)) {
 			ModuleThaumcraft.init();
 		}
+		
+		BlacklistRegistry.registerClass(IPeripheral.class);
 		
 		TickRegistry.registerTickHandler(new TickHandler(), Side.SERVER);
 		ComputerCraftAPI.registerExternalPeripheral(TileEntity.class, peripheralHandler);

--- a/src/openperipheral/api/BlacklistRegistry.java
+++ b/src/openperipheral/api/BlacklistRegistry.java
@@ -1,6 +1,10 @@
 package openperipheral.api;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import net.minecraft.tileentity.TileEntity;
 
 import openperipheral.core.util.ReflectionHelper;
 
@@ -10,6 +14,9 @@ import openperipheral.core.util.ReflectionHelper;
  * added to this registry a Computer will not be allowed to interface with.
  */
 public class BlacklistRegistry {
+	@SuppressWarnings("unchecked")
+	// Add any classes here that should never be allowed onto the blacklist as it could be bad
+	private static List<Class<?>> cannotBlacklist = Arrays.asList(TileEntity.class, IPeripheralAdapter.class);
 	private static ArrayList<Class<?>> blacklistedTileEntities = new ArrayList<Class<?>>();
 	
 	/**
@@ -18,8 +25,15 @@ public class BlacklistRegistry {
 	 * @param targetClass
 	 * @return whether or not the class was successfully added to the blacklist
 	 */
-	public static boolean registerTileEntity(Class<?> targetClass) {
-		if (blacklistedTileEntities.contains(targetClass)) { return false; }
+	public static boolean registerClass(Class<?> targetClass) {
+		if (cannotBlacklist.contains(targetClass)) {
+			System.err.println(String.format("Cannot blacklist %s, it would break all the things!", targetClass.getName()));
+			return false;
+		}
+		if (blacklistedTileEntities.contains(targetClass)) {
+			System.out.println(String.format("Class %s is already blacklisted", targetClass.getName()));
+			return false;
+		}
 		System.out.println(String.format("Adding class %s to the blacklist", targetClass.getName()));
 		return blacklistedTileEntities.add(targetClass);
 	}
@@ -30,9 +44,9 @@ public class BlacklistRegistry {
 	 * @param className
 	 * @return whether or not the class was successfully added to the blacklist
 	 */
-	public static boolean registerTileEntity(String className) {
+	public static boolean registerClass(String className) {
 		Class<?> targetClass = ReflectionHelper.getClass(className);
-		return registerTileEntity(targetClass);
+		return registerClass(targetClass);
 	}
 	
 	/**
@@ -41,7 +55,7 @@ public class BlacklistRegistry {
 	 * @param checkClass
 	 * @return whether or not the class is registered
 	 */
-	public static boolean contains(Class<?> checkClass) {
+	public static boolean containsClass(Class<?> checkClass) {
 		return blacklistedTileEntities.contains(checkClass);
 	}
 	
@@ -51,8 +65,8 @@ public class BlacklistRegistry {
 	 * @param checkClass
 	 * @return whether or not the class is registered
 	 */
-	public static boolean contains(String className) {
+	public static boolean containsClass(String className) {
 		Class<?> checkClass = ReflectionHelper.getClass(className);
-		return contains(checkClass);
+		return containsClass(checkClass);
 	}
 }

--- a/src/openperipheral/core/PeripheralHandler.java
+++ b/src/openperipheral/core/PeripheralHandler.java
@@ -5,7 +5,6 @@ import java.util.Map.Entry;
 import java.util.WeakHashMap;
 
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityCommandBlock;
 import openperipheral.api.BlacklistRegistry;
 import openperipheral.core.interfaces.IPeripheralProvider;
 import openperipheral.core.peripheral.HostedPeripheral;
@@ -34,7 +33,7 @@ public class PeripheralHandler implements IPeripheralHandler {
 
 	@Override
 	public IHostedPeripheral getPeripheral(TileEntity tile) {
-		if (BlacklistRegistry.contains(tile.getClass())) { return null; }
+		if (BlacklistRegistry.containsClass(tile.getClass())) { return null; }
 
 		if (tile instanceof IPeripheralProvider) { return ((IPeripheralProvider)tile).providePeripheral(tile.worldObj); }
 		

--- a/src/openperipheral/core/integration/ModuleThaumcraft.java
+++ b/src/openperipheral/core/integration/ModuleThaumcraft.java
@@ -2,6 +2,7 @@ package openperipheral.core.integration;
 
 import java.util.HashMap;
 
+import openperipheral.api.BlacklistRegistry;
 import openperipheral.core.AdapterManager;
 import openperipheral.core.adapter.thaumcraft.AdapterAspectContainer;
 import openperipheral.core.adapter.thaumcraft.AdapterNode;
@@ -13,6 +14,11 @@ public class ModuleThaumcraft {
 	public static void init() {
 		AdapterManager.addPeripheralAdapter(new AdapterAspectContainer());
 		AdapterManager.addPeripheralAdapter(new AdapterNode());
+		
+		// These have nothing to interact with, but were registering, removing them
+		BlacklistRegistry.registerClass("thaumcraft.common.tiles.TileArcaneBoreBase");
+		BlacklistRegistry.registerClass("thaumcraft.common.tiles.TileBellows");
+		BlacklistRegistry.registerClass("thaumcraft.common.tiles.TileTable");
 	}
 	
 	public static void entityToMap(Entity entity, HashMap map, Vec3 relativePos) {

--- a/src/openperipheral/core/integration/ModuleVanilla.java
+++ b/src/openperipheral/core/integration/ModuleVanilla.java
@@ -2,7 +2,6 @@ package openperipheral.core.integration;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Map;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
@@ -19,9 +18,13 @@ import net.minecraft.entity.passive.EntityWolf;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.tileentity.TileEntityCommandBlock;
+import net.minecraft.tileentity.TileEntityDaylightDetector;
+import net.minecraft.tileentity.TileEntityEnchantmentTable;
 import net.minecraft.util.EnumMovingObjectType;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
+import openperipheral.api.BlacklistRegistry;
 import openperipheral.core.AdapterManager;
 import openperipheral.core.adapter.vanilla.AdapterBeacon;
 import openperipheral.core.adapter.vanilla.AdapterBrewingStand;
@@ -44,6 +47,12 @@ public class ModuleVanilla {
 		AdapterManager.addPeripheralAdapter(new AdapterRecordPlayer());
 		AdapterManager.addPeripheralAdapter(new AdapterBeacon());
 		AdapterManager.addPeripheralAdapter(new AdapterMobSpawner());
+		
+		// These have nothing to interact with, but were registering, removing them
+		BlacklistRegistry.registerClass(TileEntityEnchantmentTable.class);
+		BlacklistRegistry.registerClass(TileEntityDaylightDetector.class);
+		// TODO: Fix this, it means that we don't handle it, but it also means CC doesn't handle it when on a network
+		BlacklistRegistry.registerClass(TileEntityCommandBlock.class);
 	}
 	
 	public static void entityToMap(Entity entity, HashMap map, Vec3 relativePos) {


### PR DESCRIPTION
This was just a thought that I had, and I discussed with @NeverCast, he thought it sounded good, however has I wasn't completely sure I thought I'd PR it instead of push it.

Basically this adds the ability for other mods to register classes to us that they don't want us to allow the computer to interact with. It also has the added bonus for us where we can remove certain things that the computer handles that it shouldn't as it has no methods other than `listMethods`, a fantastic example being the Enchantment Table.

I've added some items from Vanilla and Thaumcraft that I knew for sure didn't need to be wrapped, I also added the `IPeripheral` to the list as well, just as initial examples, I'm sure we could find more that really don't need to be in.

The API also defines a list of classes that can never be added to the blacklist as it may break things, such as `TileEntity`

Known Bug:
— This one is an existing bug, and this solution did not fix it (nor was it intended to); Command Blocks return null from us, but ComputerCraft doesn't handle them unless it's directly attached to the computer, instead of via network cables. Similar report was made on issue #61

Hopefully you can see what I've done here and see the merit and uses for it, but let me know what you think, both for us and mods that use our API.
