### PR TITLE
Add support for the Steam Turbine from Railcraft

### DIFF
--- a/src/openperipheral/core/adapter/railcraft/AdapterTileSteamTurbine.java
+++ b/src/openperipheral/core/adapter/railcraft/AdapterTileSteamTurbine.java
@@ -1,0 +1,47 @@
+package openperipheral.core.adapter.railcraft;
+
+import cpw.mods.fml.common.FMLLog;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import dan200.computer.api.IComputerAccess;
+import openperipheral.api.IPeripheralAdapter;
+import openperipheral.api.LuaMethod;
+import openperipheral.api.LuaType;
+import openperipheral.core.util.CallWrapper;
+
+public class AdapterTileSteamTurbine implements IPeripheralAdapter {
+
+  private static final String QUALIFIED_NAME_TURBINE = "mods.railcraft.common.blocks.machine.alpha.TileSteamTurbine";
+  
+  @Override
+  public Class getTargetClass() {
+    try {
+      return Class.forName(QUALIFIED_NAME_TURBINE);
+    } catch (ClassNotFoundException e) {
+      return null; // Railcraft isn't loaded?
+    }
+  }
+
+
+  
+  @LuaMethod(description = "Get the undamagedness of the rotor, from 0% (dead) to 100% (brand new)", returnType = LuaType.NUMBER)
+  public Integer getTurbineRotorStatus(IComputerAccess computer, Object tileSteamTurbine) throws Exception{
+    IInventory inventory = new CallWrapper<IInventory>().call(tileSteamTurbine, "getInventory");
+    if (inventory != null && inventory.getSizeInventory() >= 1) {
+      ItemStack itemStack = inventory.getStackInSlot(0);
+      if (itemStack != null) {
+        Item item = itemStack.getItem();
+        if (item != null ){
+          return 100-(int)(itemStack.getItemDamage() * 100.0 / item.getMaxDamage());
+        }
+      }
+    }
+    return null; 
+  }
+  
+  @LuaMethod(description = "Get power output percentage", returnType = LuaType.NUMBER)
+  public double getTurbineOutput(IComputerAccess computer, Object tileSteamTurbine) {
+    return new CallWrapper<Float>().call(tileSteamTurbine, "getOutput");
+  }
+}

--- a/src/openperipheral/core/integration/ModuleRailcraft.java
+++ b/src/openperipheral/core/integration/ModuleRailcraft.java
@@ -15,11 +15,13 @@ import net.minecraft.entity.item.EntityMinecart;
 import net.minecraft.util.Vec3;
 import openperipheral.core.AdapterManager;
 import openperipheral.core.adapter.AdapterTicketMachine;
+import openperipheral.core.adapter.railcraft.AdapterTileSteamTurbine;
 
 public class ModuleRailcraft {
 
 	public static void init() {
 		AdapterManager.addPeripheralAdapter(new AdapterTicketMachine());
+		AdapterManager.addPeripheralAdapter(new AdapterTileSteamTurbine());
 	}
 
 	public static void entityToMap(Entity entity, HashMap map, Vec3 relativePos) {


### PR DESCRIPTION
Because of the weirdness of Railcraft's IC2-integrated Steam Turbine, querying it only gives you a rather useless fluid tank at the moment. So this ads some useful methods, to get output power (percentage) and the repairness of the turbine rotor. 
