### PR TITLE
Fixed build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Compiling
 
 You will need Git.
 
-Run: git clone git://github.com/OpenMods/OpenPeripheral; && cd OpenPeripheral
+Run: git clone --recursive git://github.com/OpenMods/OpenPeripheral; && cd OpenPeripheral
 
 It should download the repository and cd into the repository.
 


### PR DESCRIPTION
Fixed the build instructions to ensure that the submodule OpenModsLib is also cloned. This is btw the reason for issue #211.
